### PR TITLE
Keep downloading data if endpoint error occurs and fix wrong logger message

### DIFF
--- a/data_pr_downloader.py
+++ b/data_pr_downloader.py
@@ -35,7 +35,11 @@ def get_datasets(data_pr_catalog, amount_to_download=None):
 
         for distribution in dataset['distribution']:
             file_extension = guess_extension(distribution['mediaType'])
-            response = requests.get(distribution['downloadURL'], stream=True)
+            try:
+                response = requests.get(distribution['downloadURL'], stream=True)
+            except Exception as e:
+                logger.error('Error requesting data: %s', e)
+                continue
 
             logger.debug(f"Downloading distribution: {distribution['mediaType']}")
 

--- a/data_pr_downloader.py
+++ b/data_pr_downloader.py
@@ -55,7 +55,7 @@ def main():
     try:
         get_datasets(DATA_PR_CATALOG_PATH)
     except Exception as e:
-        logger.error('Error at get_new_data_pr_catalog: %s', e)
+        logger.error('Error at get_datasets: %s', e)
 
 if __name__ == '__main__':
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
When downloading, a missing endpoint causes the application to end.   I added an exception so it keeps downloading even if an endpoint fails.

The user can then search the log and download the missing ones if needed.
